### PR TITLE
🐛 Fix configuration resolution issue and OTel service file merging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 allprojects {
     group = "com.ryandens"
-    version = "0.3.1"
+    version = "0.3.2"
     apply<com.diffplug.gradle.spotless.SpotlessPlugin>()
 
     repositories {

--- a/example-projects/buildSrc/build.gradle.kts
+++ b/example-projects/buildSrc/build.gradle.kts
@@ -8,7 +8,7 @@ repositories {
 }
 /* uncomment when doing local testing on this project, leave commented out for functional test to resolve latest plugin
 dependencies {
-  implementation("com.ryandens:otel:0.3.1")
-  implementation("com.ryandens:plugin:0.3.1")
+  implementation("com.ryandens:otel:0.3.2")
+  implementation("com.ryandens:plugin:0.3.2")
 }
 */

--- a/example-projects/custom-instrumentation/build.gradle.kts
+++ b/example-projects/custom-instrumentation/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
 
 tasks.shadowJar {
   relocate("io.opentelemetry.api", "io.opentelemetry.javaagent.shaded.io.opentelemetry.api")
+  relocate("io.opentelemetry.semconv", "io.opentelemetry.javaagent.shaded.io.opentelemetry.semconv")
+  relocate("io.opentelemetry.context", "io.opentelemetry.javaagent.shaded.io.opentelemetry.context")
 }
 
 tasks.assemble {

--- a/otel/build.gradle.kts
+++ b/otel/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(platform("org.jetbrains.kotlin:kotlin-bom"))
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
     implementation(project(":plugin"))
+    implementation("gradle.plugin.com.github.johnrengelman:shadow:7.1.2")
     testImplementation(platform("org.junit:junit-bom:5.8.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/otel/src/main/kotlin/com/ryandens/javaagent/otel/JavaagentOTelModificationPlugin.kt
+++ b/otel/src/main/kotlin/com/ryandens/javaagent/otel/JavaagentOTelModificationPlugin.kt
@@ -1,10 +1,10 @@
 package com.ryandens.javaagent.otel
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.ryandens.javaagent.JavaagentBasePlugin
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.DuplicatesStrategy
-import org.gradle.jvm.tasks.Jar
 import java.io.File
 
 /**
@@ -36,10 +36,13 @@ class JavaagentOTelModificationPlugin : Plugin<Project> {
         }
 
         project.plugins.apply(JavaagentBasePlugin::class.java)
-        val extendedAgent = project.tasks.register("extendedAgent", Jar::class.java) { jar ->
+        val extendedAgent = project.tasks.register("extendedAgent", ShadowJar::class.java) { jar ->
             jar.inputs.files(otelInstrumentation)
             jar.archiveFileName.set("extended-opentelemetry-javaagent.jar")
             jar.destinationDirectory.set(File(project.buildDir, "agents"))
+            jar.mergeServiceFiles {
+                it.include("inst/META-INF/services/*")
+            }
             jar.from(otel.map { project.zipTree(it.singleFile) })
             jar.from(otelExtension) {
                 it.into("extensions")

--- a/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentApplicationDistributionPlugin.kt
+++ b/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentApplicationDistributionPlugin.kt
@@ -9,7 +9,6 @@ import org.gradle.api.distribution.plugins.DistributionPlugin
 import org.gradle.api.internal.plugins.WindowsStartScriptGenerator
 import org.gradle.api.plugins.ApplicationPlugin
 import org.gradle.api.tasks.application.CreateStartScripts
-import java.io.File
 
 /**
  * Gradle plugin for configuration of the [DistributionPlugin.MAIN_DISTRIBUTION_NAME] after it has been configured by
@@ -47,12 +46,10 @@ class JavaagentApplicationDistributionPlugin : Plugin<Project>, JavaagentPlugin 
             // here. Instead, when we put in a placeholder String so that when we generate the start script we can
             // unescape the defaultJvmOpts String and replace directly replace our placeholder with the environment
             // variable that corresponds to the distribution installation's home directory
-            it.defaultJvmOpts = javaagentConfiguration.get().asPath.split(":").map { jar -> "-javaagent:COM_RYANDENS_APP_HOME_ENV_VAR_PLACEHOLDER/$destinationDirectory/${File(jar).name}" }
-                .plus(
-                    it.defaultJvmOpts ?: listOf()
-                )
+            it.defaultJvmOpts = listOf("-javaagent:COM_RYANDENS_JAVAAGENTS_PLACEHOLDER.jar")
+                .plus(it.defaultJvmOpts ?: listOf())
             // custom start script generator that replaces the placeholder
-            it.unixStartScriptGenerator = JavaagentAwareStartScriptGenerator()
+            it.unixStartScriptGenerator = JavaagentAwareStartScriptGenerator(javaagentConfiguration)
             // TODO build support for windows
             it.windowsStartScriptGenerator = WindowsStartScriptGenerator()
         }


### PR DESCRIPTION
- fixes issue where the `javaagent` configuration was resolved at configuration time when using the `javaagent-application-distribution` plugin. Now, configuration resolution is deferred to when the start script is being written rather than when the task is being configured
- fixes issue where the extended OpenTelemetry javaagent had merged service files. This requires the reintroduction of the shadow jar plugin as a depednency, but only for the purpose of using the ShadowJar task (the shadow jar plugin is never applied). The ShadowJar task is preferred to the Jar task because it knows how to merge service files. Ripping off that code would require a lot of copy-pasting and maintenance as it would essentially require an `OTelJar` task. Rather than maintain that, for now I prefer to simply have the transitive dependency on the shadow plugin. Contributions eliminating this dependency are welcomed