### PR TITLE
:sparkles: Sign plugins with Sigstore on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release-build:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4.1.7
       - uses: actions/setup-java@v4.3.0

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -19,4 +19,5 @@ dependencies {
     implementation(buildlibs.kotlin)
     implementation(buildlibs.nebula.apache.license)
     implementation(buildlibs.spotless)
+    implementation(buildlibs.sigstore)
 }

--- a/build-logic/src/main/kotlin/com.ryandens.plugin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/com.ryandens.plugin-conventions.gradle.kts
@@ -1,9 +1,12 @@
+import dev.sigstore.sign.tasks.SigstoreSignFilesTask
+import org.gradle.internal.extensions.stdlib.capitalized
 import org.gradle.kotlin.dsl.`java-gradle-plugin`
 import org.gradle.kotlin.dsl.`maven-publish`
 
 plugins {
     `java-gradle-plugin`
     `maven-publish`
+    id("dev.sigstore.sign")
     id("com.gradle.plugin-publish")
     id("org.jetbrains.kotlin.jvm")
     id("com.netflix.nebula.maven-apache-license")
@@ -18,6 +21,15 @@ spotless {
     kotlin {
         ktlint()
     }
+}
+
+tasks.publishPlugins {
+    dependsOn(
+        publishing.publications.map {
+                publication ->
+            tasks.named<SigstoreSignFilesTask>("sigstoreSign${publication.name.capitalized()}Publication")
+        },
+    )
 }
 
 gradlePlugin {

--- a/gradle/buildlibs.versions.toml
+++ b/gradle/buildlibs.versions.toml
@@ -6,6 +6,7 @@ spotless = { module = "com.diffplug.spotless:com.diffplug.spotless.gradle.plugin
 plugin-publish = { module = "com.gradle.plugin-publish:com.gradle.plugin-publish.gradle.plugin", version = "1.3.0"}
 kotlin = { module = "org.jetbrains.kotlin.jvm:org.jetbrains.kotlin.jvm.gradle.plugin", version = "1.9.25" }
 nebula-apache-license = { module = "com.netflix.nebula.maven-apache-license:com.netflix.nebula.maven-apache-license.gradle.plugin", version = "21.1.0"}
+sigstore = { module = "dev.sigstore.sign:dev.sigstore.sign.gradle.plugin", version = "1.0.0" }
 
 [plugins]
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
- **:lock: grant release workflow access to ID token for signing**
- **:heavy_plus_sign: add sigstore sign gradle plugin dependency**
- **:sparkles: sign plugins with sigstore**
