### PR TITLE
:bug: Fix bug with consuming OTel extensions

### DIFF
--- a/example-projects/app/build.gradle.kts
+++ b/example-projects/app/build.gradle.kts
@@ -6,7 +6,11 @@ plugins {
 
 dependencies {
   otel("io.opentelemetry.javaagent:opentelemetry-javaagent:2.8.0")
-  otelExtension("io.opentelemetry.contrib:opentelemetry-samplers:1.39.0-alpha")
+  otelExtension("com.google.cloud.opentelemetry:exporter-auto:0.33.0-alpha") {
+      artifact {
+          classifier = "shaded"
+      }
+  }
   otelInstrumentation(project(":custom-instrumentation", "shadow"))
 }
 

--- a/example-projects/app/build.gradle.kts
+++ b/example-projects/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 dependencies {
   otel("io.opentelemetry.javaagent:opentelemetry-javaagent:2.8.0")
-  otelExtension("io.opentelemetry.contrib:opentelemetry-samplers:1.32.0-alpha")
+  otelExtension("io.opentelemetry.contrib:opentelemetry-samplers:1.39.0-alpha")
   otelInstrumentation(project(":custom-instrumentation", "shadow"))
 }
 

--- a/example-projects/buildSrc/build.gradle.kts
+++ b/example-projects/buildSrc/build.gradle.kts
@@ -6,9 +6,11 @@ repositories {
     gradlePluginPortal()
     mavenLocal()
 }
-/* uncomment when doing local testing on this project, leave commented out for functional test to resolve latest plugin
 dependencies {
-  implementation("com.ryandens:otel:0.4.2")
-  implementation("com.ryandens:plugin:0.4.2")
+    /* uncomment when doing local testing on this project, leave commented out for functional test to resolve latest plugin
+    implementation("com.ryandens:otel:0.6.1")
+    implementation("com.ryandens:plugin:0.6.1")
+    */
+    implementation("io.opentelemetry.instrumentation.muzzle-generation:io.opentelemetry.instrumentation.muzzle-generation.gradle.plugin:2.8.0-alpha")
+    implementation("io.opentelemetry.instrumentation.muzzle-check:io.opentelemetry.instrumentation.muzzle-check.gradle.plugin:2.8.0-alpha")
 }
-*/

--- a/example-projects/custom-instrumentation/build.gradle.kts
+++ b/example-projects/custom-instrumentation/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
   id("com.ryandens.javaagent.example.java-library-conventions")
   id("io.opentelemetry.instrumentation.muzzle-check")
   id("io.opentelemetry.instrumentation.muzzle-generation")
-  id("com.github.johnrengelman.shadow")
+  id("com.gradleup.shadow")
 }
 
 tasks.shadowJar {

--- a/example-projects/custom-instrumentation/build.gradle.kts
+++ b/example-projects/custom-instrumentation/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
   id("com.ryandens.javaagent.example.java-library-conventions")
-  id("io.opentelemetry.instrumentation.muzzle-check") version "1.13.1-alpha"
-  id("io.opentelemetry.instrumentation.muzzle-generation") version "1.13.1-alpha"
+  id("io.opentelemetry.instrumentation.muzzle-check")
+  id("io.opentelemetry.instrumentation.muzzle-generation")
   id("com.github.johnrengelman.shadow")
 }
 

--- a/example-projects/custom-instrumentation/src/main/java/com/ryandens/example/SampleInstrumentation.java
+++ b/example-projects/custom-instrumentation/src/main/java/com/ryandens/example/SampleInstrumentation.java
@@ -39,7 +39,6 @@ public final class SampleInstrumentation implements TypeInstrumentation {
                                @Advice.Local("otelContext") Context context,
                                @Advice.Local("otelScope") Scope scope) {
       Context parentContext = Context.current();
-      // TODO helper classes don't seem to work for some reaso
       span = Singletons.INSTANCE.tracer.spanBuilder("iterative").setSpanKind(SpanKind.INTERNAL).setParent(parentContext).startSpan();
       context = parentContext.with(span);
       scope = context.makeCurrent();

--- a/example-projects/custom-instrumentation/src/main/java/com/ryandens/example/SampleInstrumentation.java
+++ b/example-projects/custom-instrumentation/src/main/java/com/ryandens/example/SampleInstrumentation.java
@@ -1,4 +1,4 @@
-package io.opentelemetry.javaagent.instrumentation.ryandens;
+package com.ryandens.example;
 
 
 import io.opentelemetry.api.trace.Span;

--- a/example-projects/custom-instrumentation/src/main/java/com/ryandens/example/SampleInstrumentationModule.java
+++ b/example-projects/custom-instrumentation/src/main/java/com/ryandens/example/SampleInstrumentationModule.java
@@ -1,4 +1,4 @@
-package io.opentelemetry.javaagent.instrumentation.ryandens;
+package com.ryandens.example;
 
 import com.google.auto.service.AutoService;
 import io.opentelemetry.javaagent.extension.instrumentation.InstrumentationModule;
@@ -16,5 +16,10 @@ public final class SampleInstrumentationModule extends InstrumentationModule {
   @Override
   public List<TypeInstrumentation> typeInstrumentations() {
     return Collections.singletonList(new SampleInstrumentation());
+  }
+
+  @Override
+  public boolean isHelperClass(String className) {
+    return className.contains("ryandens");
   }
 }

--- a/example-projects/custom-instrumentation/src/main/java/com/ryandens/example/Singletons.java
+++ b/example-projects/custom-instrumentation/src/main/java/com/ryandens/example/Singletons.java
@@ -1,4 +1,4 @@
-package io.opentelemetry.javaagent.instrumentation.ryandens;
+package com.ryandens.example;
 
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Tracer;

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAME
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 org.gradle.configuration-cache=true
 org.gradle.caching=true
-version=0.6.1
+version=0.7.0
 group=com.ryandens

--- a/otel/build.gradle.kts
+++ b/otel/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 dependencies {
     implementation(project(":plugin"))
-    implementation("com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:8.3.3")
     testImplementation(platform("org.junit:junit-bom:5.11.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/otel/build.gradle.kts
+++ b/otel/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation(project(":plugin"))
-    implementation("gradle.plugin.com.github.johnrengelman:shadow:8.0.0")
+    implementation("com.gradleup.shadow:com.gradleup.shadow.gradle.plugin:8.3.3")
     testImplementation(platform("org.junit:junit-bom:5.11.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     testImplementation("org.junit.jupiter:junit-jupiter-params")

--- a/otel/src/functionalTest/kotlin/com/ryandens/javaagent/otel/OTelJavaagentPluginFunctionalTest.kt
+++ b/otel/src/functionalTest/kotlin/com/ryandens/javaagent/otel/OTelJavaagentPluginFunctionalTest.kt
@@ -17,7 +17,7 @@ class OTelJavaagentPluginFunctionalTest {
         val runner = GradleRunner.create()
         runner.forwardOutput()
         runner.withPluginClasspath()
-        runner.withArguments("extendedAgent", "run")
+        runner.withArguments("mergeInstrumentationServiceFiles", "extendedAgent", "run")
         runner.withProjectDir(projectDir)
         runner.withDebug(true)
         val result = runner.build()
@@ -25,16 +25,14 @@ class OTelJavaagentPluginFunctionalTest {
         // Verify the result
         // TODO use testcontainers to start an otel fake backend and retrieve spans from it here to verify instrumentation worked
         assertTrue(result.output.contains("AgentInstaller - Installed 1 extension(s)"))
-        assertTrue(result.output.contains("InstrumentationLoader - Installed 1 instrumenter(s)"))
-        /* TOOD fix this
+        assertTrue(result.output.contains("InstrumentationLoader - Installed 254 instrumenter(s)"))
         assertTrue(
             result.output.contains(
-                "Applying instrumentation: sample [class io.opentelemetry.javaagent.instrumentation.ryandens.SampleInstrumentationModule]",
+                "Applying instrumentation: sample [class com.ryandens.example.SampleInstrumentationModule]",
             ),
         )
         assertTrue(result.output.contains("LoggingSpanExporter - 'iterative'")) // span name
         assertTrue(result.output.contains(" [tracer: FibonacciTracer:]")) // tracer name
-         */
         val agent = File(projectDir, "app/build/agents/extended-opentelemetry-javaagent.jar")
         assertTrue(agent.exists())
     }

--- a/otel/src/functionalTest/kotlin/com/ryandens/javaagent/otel/OTelJavaagentPluginFunctionalTest.kt
+++ b/otel/src/functionalTest/kotlin/com/ryandens/javaagent/otel/OTelJavaagentPluginFunctionalTest.kt
@@ -19,10 +19,14 @@ class OTelJavaagentPluginFunctionalTest {
         runner.withPluginClasspath()
         runner.withArguments("extendedAgent", "run")
         runner.withProjectDir(projectDir)
+        runner.withDebug(true)
         val result = runner.build()
 
         // Verify the result
         // TODO use testcontainers to start an otel fake backend and retrieve spans from it here to verify instrumentation worked
+        assertTrue(result.output.contains("AgentInstaller - Installed 1 extension(s)"))
+        assertTrue(result.output.contains("InstrumentationLoader - Installed 1 instrumenter(s)"))
+        /* TOOD fix this
         assertTrue(
             result.output.contains(
                 "Applying instrumentation: sample [class io.opentelemetry.javaagent.instrumentation.ryandens.SampleInstrumentationModule]",
@@ -30,6 +34,7 @@ class OTelJavaagentPluginFunctionalTest {
         )
         assertTrue(result.output.contains("LoggingSpanExporter - 'iterative'")) // span name
         assertTrue(result.output.contains(" [tracer: FibonacciTracer:]")) // tracer name
+         */
         val agent = File(projectDir, "app/build/agents/extended-opentelemetry-javaagent.jar")
         assertTrue(agent.exists())
     }

--- a/otel/src/main/kotlin/com/ryandens/javaagent/otel/MergeServiceFiles.kt
+++ b/otel/src/main/kotlin/com/ryandens/javaagent/otel/MergeServiceFiles.kt
@@ -1,0 +1,72 @@
+package com.ryandens.javaagent.otel
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.io.FileOutputStream
+import java.io.OutputStreamWriter
+import java.io.PrintWriter
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.util.stream.Collectors
+import javax.inject.Inject
+
+/**
+ * Internal task to merge service files between custom instrumentation JArs and the OpenTelemetry Javaagent.
+ *
+ * Inspired by
+ * [Micronaut](https://github.com/micronaut-projects/micronaut-gradle-plugin/blob/eb9d2b3ab4b3fc71379fc3c1c6df30de761576be/aot-plugin/src/main/java/io/micronaut/gradle/aot/MergeServiceFiles.java#L42)
+ * in lieu of a built-in solution in Gradle as referenced [here](https://github.com/gradle/gradle/issues/18751).
+ */
+@CacheableTask
+abstract class MergeServiceFiles
+    @Inject
+    constructor(private val fileSystemOperations: FileSystemOperations) :
+    DefaultTask() {
+        @get:InputFiles
+        @get:PathSensitive(PathSensitivity.RELATIVE)
+        abstract val inputFiles: ConfigurableFileCollection
+
+        @get:OutputDirectory
+        abstract val outputDirectory: DirectoryProperty
+
+        @TaskAction
+        fun execute() {
+            val serviceFiles: Set<File> =
+                inputFiles.asFileTree.matching { f -> f.include("META-INF/services/**").include("inst/META-INF/services/**") }
+                    .files
+            val outputDir: File = outputDirectory.get().dir("META-INF/services").asFile
+            fileSystemOperations.delete {
+                it.delete(outputDir)
+            }
+            outputDir.mkdirs()
+            val perService: Map<String, List<File>> =
+                serviceFiles.stream()
+                    .collect(Collectors.groupingBy(File::getName))
+            for ((serviceType, files) in perService) {
+                val mergedServiceFile = File(outputDir, serviceType)
+                try {
+                    PrintWriter(
+                        OutputStreamWriter(
+                            FileOutputStream(mergedServiceFile),
+                            StandardCharsets.UTF_8,
+                        ),
+                    ).use { wrt ->
+                        for (file in files) {
+                            Files.readAllLines(file.toPath()).forEach(wrt::println)
+                        }
+                    }
+                } catch (e: Exception) {
+                    throw RuntimeException(e)
+                }
+            }
+        }
+    }


### PR DESCRIPTION
Fixes #167

Fixes #17 


The shadow plugin has some odd conventions I don't fully understand, it's long been a goal of this project to eliminate our usage of it (except in tests) so that consuming projects don't need it on the classpath unless they have a use for it. We instead merge service files manually in the style of Micronaut and await https://github.com/gradle/gradle/issues/18751


