### PR TITLE
Make the use of otelExtension optional

### DIFF
--- a/otel/src/main/kotlin/com/ryandens/javaagent/otel/JavaagentOTelModificationPlugin.kt
+++ b/otel/src/main/kotlin/com/ryandens/javaagent/otel/JavaagentOTelModificationPlugin.kt
@@ -5,6 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.DuplicatesStrategy
 import org.gradle.jvm.tasks.Jar
+import java.io.File
 
 /**
  * Enables easy consumption of external extensions and instrumentation libraries by creating a new jar with extra
@@ -54,7 +55,11 @@ class JavaagentOTelModificationPlugin : Plugin<Project> {
                 jar.from(otel.map { project.zipTree(it.singleFile) }) {
                     it.exclude("inst/META-INF/services/**")
                 }
-                jar.from(otelExtension.map { it.singleFile }) {
+                jar.from(
+                    otelExtension.map { config ->
+                        if (!config.isEmpty) config.singleFile else emptyList<File>()
+                    },
+                ) {
                     it.into("extensions")
                 }
                 jar.manifest {


### PR DESCRIPTION
This PR fixes #176 by making `otelExtension` optional (i.e. if you do not need to copy additional shaded jars into the `extensions` folder of the modified otel distribution).

I've tested this on my own project, as well as via the project's functional test (sorry I didn't update the test as it's not really set up to test permutations of config).

### Testing evidence

I commented out the `otelExtension` from the example  project's `build.gradle.kts` file:

```
dependencies {
  otel("io.opentelemetry.javaagent:opentelemetry-javaagent:2.13.0")
//  otelExtension("com.google.cloud.opentelemetry:exporter-auto:0.33.0-alpha") {
//      artifact {
//          classifier = "shaded"
//      }
//  }
  otelInstrumentation(project(":custom-instrumentation", "shadow"))
}
```

Result of functional test before this change:

```
org.gradle.testkit.runner.UnexpectedBuildFailure: Unexpected build execution failure in /var/folders/5k/tdf65gsn21j53hjrx5q8lfmr0000gn/T/junit-15534189899941085406 with arguments [mergeInstrumentationServiceFiles, extendedAgent, run]

Output:
> Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :buildSrc:generateExternalPluginSpecBuilders
> Task :buildSrc:extractPrecompiledScriptPluginPlugins
> Task :buildSrc:compilePluginsBlocks
> Task :buildSrc:generatePrecompiledScriptPluginAccessors
> Task :buildSrc:generateScriptPluginAdapters
> Task :buildSrc:pluginDescriptors
> Task :buildSrc:processResources
> Task :buildSrc:compileKotlin
> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:classes
> Task :buildSrc:jar

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':app:extendedAgent'.
> Expected configuration ':app:otelExtension' to contain exactly one file, however, it contains no files.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 16s
9 actionable tasks: 9 executed

	at app//org.gradle.testkit.runner.internal.DefaultGradleRunner.lambda$build$2(DefaultGradleRunner.java:274)
	at app//org.gradle.testkit.runner.internal.DefaultGradleRunner.run(DefaultGradleRunner.java:367)
	at app//org.gradle.testkit.runner.internal.DefaultGradleRunner.build(DefaultGradleRunner.java:272)
	at app//com.ryandens.javaagent.otel.OTelJavaagentPluginFunctionalTest.can run task(OTelJavaagentPluginFunctionalTest.kt:23)
	at java.base@17.0.4/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base@17.0.4/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base@17.0.4/java.util.ArrayList.forEach(ArrayList.java:1511)
```

Result of functional test after this change:

```
./gradlew functionalTest
Reusing configuration cache.

BUILD SUCCESSFUL in 29s

```