### PR TITLE
Add minimal Jib container-customizer extension support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Ignore Gradle project-specific cache directory
 .gradle
 
+# claude
+.claude
+
 # Ignore Gradle build output directory
 build
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,5 @@ org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAME
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 org.gradle.configuration-cache=true
 org.gradle.caching=true
-version=0.11.0
+version=0.12.0
 group=com.ryandens

--- a/plugin/src/main/java/com/ryandens/javaagent/JibExtensionConfiguration.java
+++ b/plugin/src/main/java/com/ryandens/javaagent/JibExtensionConfiguration.java
@@ -1,6 +1,8 @@
 package com.ryandens.javaagent;
 
 import java.io.File;
+import javax.inject.Inject;
+import org.gradle.api.Project;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Input;
@@ -17,7 +19,16 @@ public class JibExtensionConfiguration {
 
   private final ListProperty<File> javaagentFiles;
 
-  /** Instantiated by Jib's plugin extension mechanism. */
+  /**
+   * Instantiated by Jib's plugin extension mechanism
+   *
+   * <p>Not compatible with configuration cache due to usage of Project at task execution time.
+   */
+  @Inject
+  public JibExtensionConfiguration(final Project project) {
+    this(project.getObjects());
+  }
+
   public JibExtensionConfiguration(final ObjectFactory objectFactory) {
     javaagentFiles = objectFactory.listProperty(File.class);
   }

--- a/plugin/src/main/java/com/ryandens/javaagent/JibExtensionConfiguration.java
+++ b/plugin/src/main/java/com/ryandens/javaagent/JibExtensionConfiguration.java
@@ -1,0 +1,21 @@
+package com.ryandens.javaagent;
+
+import java.io.File;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.ListProperty;
+import org.gradle.api.tasks.Input;
+
+public class JibExtensionConfiguration {
+
+  private final ListProperty<File> javaagentFiles;
+
+  /** Used by tiny-jib */
+  public JibExtensionConfiguration(final ObjectFactory objectFactory) {
+    javaagentFiles = objectFactory.listProperty(File.class);
+  }
+
+  @Input
+  ListProperty<File> getJavaagentFiles() {
+    return javaagentFiles;
+  }
+}

--- a/plugin/src/main/java/com/ryandens/javaagent/JibExtensionConfiguration.java
+++ b/plugin/src/main/java/com/ryandens/javaagent/JibExtensionConfiguration.java
@@ -5,15 +5,29 @@ import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.Input;
 
+/**
+ * Extra configuration for {@link JavaagentJibExtension}. Declares the javaagent files that should
+ * be copied into the container image and referenced via {@code -javaagent} JVM flags.
+ *
+ * <p>Instances are created by Jib's plugin extension mechanism via {@link
+ * org.gradle.api.model.ObjectFactory}, so this class must have a single-argument constructor
+ * accepting {@link ObjectFactory}.
+ */
 public class JibExtensionConfiguration {
 
   private final ListProperty<File> javaagentFiles;
 
-  /** Used by tiny-jib */
+  /** Instantiated by Jib's plugin extension mechanism. */
   public JibExtensionConfiguration(final ObjectFactory objectFactory) {
     javaagentFiles = objectFactory.listProperty(File.class);
   }
 
+  /**
+   * Returns the list of javaagent {@link File}s to include in the container image. Each file is
+   * placed under {@code /opt/jib-agents/} in the image and added to the container entrypoint as a
+   * {@code -javaagent} flag. Package-private: intended to be accessed only by {@link
+   * JavaagentJibExtension}.
+   */
   @Input
   ListProperty<File> getJavaagentFiles() {
     return javaagentFiles;

--- a/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentJibExtension.kt
+++ b/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentJibExtension.kt
@@ -100,7 +100,11 @@ class JavaagentJibExtension :
                     Action<JibExtensionConfiguration> { extensionConfiguration ->
                         extensionConfiguration.javaagentFiles.set(
                             project.provider {
-                                javaagentConfiguration.get().files.map { File(destinationDirectory.get().asFile, it.name) }.toList()
+                                javaagentConfiguration
+                                    .get()
+                                    .files
+                                    .map { File(destinationDirectory.get().asFile, it.name) }
+                                    .toList()
                             },
                         )
                     },

--- a/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentJibExtension.kt
+++ b/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentJibExtension.kt
@@ -85,10 +85,20 @@ class JavaagentJibExtension :
                 it.into(destinationDirectory)
             }
 
-        listOf("jib", "jibDockerBuild", "jibBuildTar").forEach { jibTaskName ->
-            project.tasks.named(jibTaskName) { jibTask ->
-                jibTask.dependsOn(copyAgents)
+        if (project.pluginManager.hasPlugin("com.google.cloud.tools.jib")) {
+            listOf("jib", "jibDockerBuild", "jibBuildTar").forEach { jibTaskName ->
+                project.tasks.named(jibTaskName) { jibTask ->
+                    jibTask.dependsOn(copyAgents)
+                }
             }
+        } else if (project.pluginManager.hasPlugin("tel.schich.tinyjib")) {
+            listOf("tinyJibPublish", "tinyJibDocker", "tinyJibTar").forEach { jibTaskName ->
+                project.tasks.named(jibTaskName) { jibTask ->
+                    jibTask.dependsOn(copyAgents)
+                }
+            }
+        } else {
+            throw IllegalStateException("Should not be possible")
         }
 
         val jibExtension: JibExtension? = project.extensions.findByType(JibExtension::class.java)

--- a/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentJibExtension.kt
+++ b/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentJibExtension.kt
@@ -10,6 +10,8 @@ import com.google.cloud.tools.jib.gradle.JibExtension
 import com.google.cloud.tools.jib.gradle.extension.GradleData
 import com.google.cloud.tools.jib.gradle.extension.JibGradlePluginExtension
 import com.google.cloud.tools.jib.plugins.extension.ExtensionLogger
+import org.gradle.api.Action
+import org.gradle.api.GradleException
 import org.gradle.api.NamedDomainObjectProvider
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
@@ -24,31 +26,24 @@ import java.util.Optional
  */
 @ExperimentalStdlibApi
 class JavaagentJibExtension :
-    JibGradlePluginExtension<Void>,
+    JibGradlePluginExtension<JibExtensionConfiguration>,
     JavaagentPlugin {
-    override fun getExtraConfigType(): Optional<Class<Void>> = Optional.empty()
+    override fun getExtraConfigType(): Optional<Class<JibExtensionConfiguration>> = Optional.of(JibExtensionConfiguration::class.java)
 
     override fun extendContainerBuildPlan(
-        buildPlan: ContainerBuildPlan?,
-        properties: MutableMap<String, String>?,
-        extraConfig: Optional<Void>?,
+        buildPlan: ContainerBuildPlan,
+        properties: MutableMap<String, String>,
+        extraConfig: Optional<JibExtensionConfiguration>,
         gradleData: GradleData?,
         logger: ExtensionLogger?,
     ): ContainerBuildPlan {
-        checkNotNull(buildPlan)
         val entrypoint = checkNotNull(buildPlan.entrypoint)
         check(entrypoint.isNotEmpty())
+        if (extraConfig.isEmpty) {
+            throw GradleException("Javaagent Jib plugin must be provided an extraConfig containing javaagent files to configure")
+        }
 
-        val localAgentPaths =
-            checkNotNull(
-                gradleData
-                    ?.project
-                    ?.plugins
-                    ?.getPlugin(
-                        JavaagentJibExtension::class.java,
-                    )?.javaagentPathProvider
-                    ?.invoke(),
-            )
+        val localAgentPaths = extraConfig.get().javaagentFiles.get()
 
         val planBuilder = buildPlan.toBuilder()
         val newEntrypoint =
@@ -99,15 +94,18 @@ class JavaagentJibExtension :
         val jibExtension: JibExtension? = project.extensions.findByType(JibExtension::class.java)
 
         jibExtension?.pluginExtensions { extensionParametersSpec ->
-            extensionParametersSpec.pluginExtension {
-                it.implementation = "com.ryandens.javaagent.JavaagentJibExtension"
+            extensionParametersSpec.pluginExtension { extension ->
+                extension.implementation = "com.ryandens.javaagent.JavaagentJibExtension"
+                extension.configuration(
+                    Action<JibExtensionConfiguration> { extensionConfiguration ->
+                        extensionConfiguration.javaagentFiles.set(
+                            project.provider {
+                                javaagentConfiguration.get().files.map { File(destinationDirectory.get().asFile, it.name) }.toList()
+                            },
+                        )
+                    },
+                )
             }
         }
-
-        javaagentPathProvider = {
-            javaagentConfiguration.get().files.map { File(destinationDirectory.get().asFile, it.name) }
-        }
     }
-
-    private lateinit var javaagentPathProvider: () -> List<File>
 }


### PR DESCRIPTION
## Summary

- Introduces `JibExtensionConfiguration` to expose javaagent files to the Jib plugin extension via the standard extra-config mechanism
- Replaces the fragile `lateinit var javaagentPathProvider` field with proper `JibGradlePluginExtension<JibExtensionConfiguration>` typing
- Wires agent files lazily through `project.provider { }` so configuration remains deferred until task execution

## Test plan

- [x] `./gradlew :plugin:test` passes
- [ ] Manual end-to-end test with a project that uses the Jib plugin

🤖 Generated with [Claude Code](https://claude.com/claude-code)