### PR TITLE
Bump Kotlin language/api version to 2.2

### DIFF
--- a/build-logic/src/main/kotlin/com.ryandens.plugin-conventions.gradle.kts
+++ b/build-logic/src/main/kotlin/com.ryandens.plugin-conventions.gradle.kts
@@ -47,8 +47,8 @@ tasks {
         compilerOptions {
             jvmTarget = JvmTarget.JVM_17
             allWarningsAsErrors.set(true)
-            languageVersion.set(KotlinVersion.KOTLIN_2_1)
-            apiVersion.set(KotlinVersion.KOTLIN_2_1)
+            languageVersion.set(KotlinVersion.KOTLIN_2_2)
+            apiVersion.set(KotlinVersion.KOTLIN_2_2)
         }
     }
 }


### PR DESCRIPTION
## Why

Renovate PR #354 (Kotlin 2.4.0) fails CI because Kotlin 2.4.0 deprecates language version `2.1` and emits a deprecation warning. The `:plugin` Kotlin compile tasks set `allWarningsAsErrors`, so that warning becomes a hard build failure in `:plugin:compileKotlin` and `:plugin:compileFunctionalTestKotlin`.

Renovate force-pushes/rebases its branch and discards non-Renovate commits, so fixing this directly on #354 doesn't stick. Landing the bump on `main` is durable: once merged, Renovate's next rebase of #354 inherits the fix.

## Change

Bump `languageVersion` / `apiVersion` from `KOTLIN_2_1` to `KOTLIN_2_2` in `com.ryandens.plugin-conventions.gradle.kts`. `2.2` is valid under the current Kotlin 2.3.21 on `main` and is exactly what the 2.4.0 compiler recommends.

Verified with a full `./gradlew build` locally (Kotlin 2.3.21, Gradle 9.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)