### PR TITLE
:rotating_light: fix remaining 1st party build deprecation warnings with gradle 9.6.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore Gradle project-specific cache directory
 .gradle
+.kotlin
 
 # claude
 .claude

--- a/jib/build.gradle.kts
+++ b/jib/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.ryandens.plugin-conventions")
 }
 
-val plugin: Configuration by configurations.creating
+val plugin: Configuration = configurations.create("plugin")
 
 configurations {
     compileOnly {

--- a/jib/build.gradle.kts
+++ b/jib/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.gradle.kotlin.dsl.assign
 import org.gradle.plugin.compatibility.compatibility
 
 plugins {

--- a/jib/build.gradle.kts
+++ b/jib/build.gradle.kts
@@ -4,7 +4,12 @@ plugins {
     id("com.ryandens.plugin-conventions")
 }
 
-val plugin: Configuration = configurations.create("plugin")
+val plugin: Configuration =
+    configurations.create("plugin") {
+        isCanBeDeclared = true
+        isCanBeResolved = true
+        isCanBeConsumed = false
+    }
 
 configurations {
     compileOnly {


### PR DESCRIPTION
- **:fire: remove unused import**
- **:fire: remove ktolin compiler session**
- **:rotating_light: fix deprecation warning**
- **:wrench: clarify scope of plugin configuration for declaration, resolution, and consumption**
- **:see_no_evil: add kotlin dir to gitignore**
