### PR TITLE
Fix build-ordering race: track javaagent config as run-task input

### DIFF
--- a/otel/src/main/kotlin/com/ryandens/javaagent/otel/JavaagentOTelModificationPlugin.kt
+++ b/otel/src/main/kotlin/com/ryandens/javaagent/otel/JavaagentOTelModificationPlugin.kt
@@ -89,6 +89,11 @@ class JavaagentOTelModificationPlugin : Plugin<Project> {
                     it.into("inst")
                 }
             }
-        project.dependencies.add("javaagent", extendedAgent.map { project.files(it.outputs.files.singleFile) })
+        // Add the extendedAgent output via the task provider (not extendedAgent.outputs.files.singleFile,
+        // which resolves to a plain File and loses provenance). project.files(TaskProvider) carries the
+        // producing task as a builtBy dependency, so consumers of the javaagent configuration that track it
+        // as an input — e.g. the run task in JavaagentApplicationRunPlugin — establish a dependency on
+        // :extendedAgent instead of failing Gradle's implicit-dependency validation.
+        project.dependencies.add("javaagent", project.files(extendedAgent))
     }
 }

--- a/plugin/src/functionalTest/kotlin/com/ryandens/javaagent/JavaagentPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/ryandens/javaagent/JavaagentPluginFunctionalTest.kt
@@ -81,13 +81,14 @@ class JavaagentPluginFunctionalTest {
 
         createJavaagentProject(dependencies)
 
-        // The run task adds the agent jars via a CommandLineArgumentProvider that is not a tracked input, so
-        // only an explicit task dependency makes Gradle schedule :simple-agent:jar before :hello-world:run.
-        // Without it the run task can launch with -javaagent:<jar> before that jar has been produced, failing
-        // with "Error opening zip file or JAR manifest missing" (the `can attach to application run task`
-        // test above reproduces that intermittently under parallel scheduling). --dry-run prints the task
-        // execution graph in order without running anything, so asserting the ordering here catches the
-        // regression deterministically, independent of scheduling timing.
+        // The run task adds the agent jars via a CommandLineArgumentProvider that is not itself a tracked
+        // input, so the plugin registers the javaagent configuration as a task input to make Gradle schedule
+        // :simple-agent:jar before :hello-world:run. Without that, the run task can launch with
+        // -javaagent:<jar> before that jar has been produced, failing with "Error opening zip file or JAR
+        // manifest missing" (the `can attach to application run task` test above reproduces that
+        // intermittently under parallel scheduling). --dry-run prints the task execution graph in order
+        // without running anything, so asserting the ordering here catches the regression deterministically,
+        // independent of scheduling timing.
         val result = runBuild(listOf("--dry-run", ":hello-world:run"))
 
         val agentJarIndex = result.output.indexOf(":simple-agent:jar")

--- a/plugin/src/functionalTest/kotlin/com/ryandens/javaagent/JavaagentPluginFunctionalTest.kt
+++ b/plugin/src/functionalTest/kotlin/com/ryandens/javaagent/JavaagentPluginFunctionalTest.kt
@@ -74,6 +74,29 @@ class JavaagentPluginFunctionalTest {
         assertTrue(ccResult.output.contains("Reusing configuration cache."))
     }
 
+    @Test fun `run task depends on the tasks that build the javaagent artifacts`() {
+        val dependencies = """
+            javaagent project(':simple-agent')
+        """
+
+        createJavaagentProject(dependencies)
+
+        // The run task adds the agent jars via a CommandLineArgumentProvider that is not a tracked input, so
+        // only an explicit task dependency makes Gradle schedule :simple-agent:jar before :hello-world:run.
+        // Without it the run task can launch with -javaagent:<jar> before that jar has been produced, failing
+        // with "Error opening zip file or JAR manifest missing" (the `can attach to application run task`
+        // test above reproduces that intermittently under parallel scheduling). --dry-run prints the task
+        // execution graph in order without running anything, so asserting the ordering here catches the
+        // regression deterministically, independent of scheduling timing.
+        val result = runBuild(listOf("--dry-run", ":hello-world:run"))
+
+        val agentJarIndex = result.output.indexOf(":simple-agent:jar")
+        val runIndex = result.output.indexOf(":hello-world:run")
+        assertTrue(agentJarIndex >= 0, "expected :simple-agent:jar to be scheduled ahead of :hello-world:run")
+        assertTrue(runIndex >= 0, "expected :hello-world:run to be scheduled")
+        assertTrue(agentJarIndex < runIndex, "expected :simple-agent:jar to be scheduled before :hello-world:run")
+    }
+
     @Test fun `can attach to test task`() {
         // A real third-party javaagent used to verify the plugin attaches it and it logs its version banner.
         val otelVersion = "2.29.0"

--- a/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentApplicationRunPlugin.kt
+++ b/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentApplicationRunPlugin.kt
@@ -21,6 +21,19 @@ class JavaagentApplicationRunPlugin :
     ) {
         // configure the run task to use the `javaagent` flag pointing to the dependency stored in the local Maven repository
         project.tasks.named(ApplicationPlugin.TASK_RUN_NAME, JavaExec::class.java).configure {
+            // The agent jars are passed to the JVM via a CommandLineArgumentProvider (see
+            // JavaForkOptionsConfigurer), which resolves the configuration's files at execution time but is
+            // not a tracked task input. Without an explicit dependency, Gradle establishes no ordering
+            // between the run task and the tasks that build the agent jars, so under parallel execution the
+            // run task can launch with -javaagent:<jar> before that jar has been produced, failing with
+            // "Error opening zip file or JAR manifest missing".
+            //
+            // A Configuration is Buildable, so dependsOn adds the artifact-building task dependencies and
+            // fixes the ordering. Unlike inputs.files(...), it does NOT register the agent jars as tracked
+            // inputs, which avoids tripping Gradle's implicit-dependency validation for agent jars added to
+            // the configuration without a declared builtBy (e.g. the otel example's extendedAgent jar). The
+            // run task is never up-to-date, so input tracking would provide no benefit here anyway.
+            it.dependsOn(javaagentConfiguration)
             JavaForkOptionsConfigurer.configureJavaForkOptions(it, javaagentConfiguration.map { configuration -> configuration.files })
         }
     }

--- a/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentApplicationRunPlugin.kt
+++ b/plugin/src/main/kotlin/com/ryandens/javaagent/JavaagentApplicationRunPlugin.kt
@@ -23,17 +23,17 @@ class JavaagentApplicationRunPlugin :
         project.tasks.named(ApplicationPlugin.TASK_RUN_NAME, JavaExec::class.java).configure {
             // The agent jars are passed to the JVM via a CommandLineArgumentProvider (see
             // JavaForkOptionsConfigurer), which resolves the configuration's files at execution time but is
-            // not a tracked task input. Without an explicit dependency, Gradle establishes no ordering
-            // between the run task and the tasks that build the agent jars, so under parallel execution the
-            // run task can launch with -javaagent:<jar> before that jar has been produced, failing with
-            // "Error opening zip file or JAR manifest missing".
+            // not a tracked task input. Without registering the configuration as an input, Gradle
+            // establishes no ordering between the run task and the tasks that build the agent jars, so under
+            // parallel execution the run task can launch with -javaagent:<jar> before that jar has been
+            // produced, failing with "Error opening zip file or JAR manifest missing".
             //
-            // A Configuration is Buildable, so dependsOn adds the artifact-building task dependencies and
-            // fixes the ordering. Unlike inputs.files(...), it does NOT register the agent jars as tracked
-            // inputs, which avoids tripping Gradle's implicit-dependency validation for agent jars added to
-            // the configuration without a declared builtBy (e.g. the otel example's extendedAgent jar). The
-            // run task is never up-to-date, so input tracking would provide no benefit here anyway.
-            it.dependsOn(javaagentConfiguration)
+            // A Configuration is Buildable, so registering it as an input makes the run task depend on the
+            // tasks that build the agent jars, the same way JavaagentApplicationDistributionPlugin does for
+            // the start-script task. This requires every artifact added to the javaagent configuration to
+            // carry its producing-task dependency (builtBy); consumers that synthesize a plain File must
+            // preserve it (see the otel example's extendedAgent wiring).
+            it.inputs.files(javaagentConfiguration)
             JavaForkOptionsConfigurer.configureJavaForkOptions(it, javaagentConfiguration.map { configuration -> configuration.files })
         }
     }


### PR DESCRIPTION
## Problem

`JavaagentApplicationRunPlugin` wires the run task's `-javaagent` arguments through a `CommandLineArgumentProvider` (in `JavaForkOptionsConfigurer`) that resolves the `javaagent` configuration's files at **execution time**. That provider is not a tracked task input, so Gradle established **no dependency** on the tasks that build the agent jars.

Under parallel execution the run task could launch with `-javaagent:<jar>` before that jar had been produced:

```
Error opening zip file or JAR manifest missing : .../simple-agent.jar
```

Reproducible 100% locally and intermittently on CI:

```sh
./gradlew :plugin:functionalTest --tests "*can attach to application run task*" --rerun-tasks
```

## Fix

Register the `javaagent` configuration as a tracked input of the run task:

```kotlin
it.inputs.files(javaagentConfiguration)
```

A `Configuration` is `Buildable`, so input-tracking makes the run task depend on the tasks that build the agent jars — the same way `JavaagentApplicationDistributionPlugin` already wires the start-script task.

### Downstream fix in the otel modification plugin

Input-tracking requires every artifact added to the `javaagent` configuration to carry its producing-task dependency (`builtBy`). `JavaagentOTelModificationPlugin` added the `extendedAgent` output via `extendedAgent.outputs.files.singleFile`, which resolves to a plain `File` and drops that provenance — so tracking the configuration as a run-task input tripped Gradle's strict implicit-dependency validation:

```
A problem was found with the configuration of task ':app:run' (JavaExec).
  Task ':app:run' uses this output of task ':app:extendedAgent' without
  declaring an explicit or implicit dependency.
```

Fixed at the source by adding it via the task provider, which carries the producing task as a `builtBy` dependency:

```kotlin
project.dependencies.add("javaagent", project.files(extendedAgent))
```

Consumers that track the configuration now establish the `:extendedAgent` dependency automatically.

## Tests

- Added a **deterministic** regression test that asserts, via `--dry-run`, that `:simple-agent:jar` is scheduled before `:hello-world:run`. It fails without this fix and passes with it — independent of task-scheduling timing.
- The existing `can attach to application run task` test also reproduces the race (verified: 3/3 failures without the fix, 3/3 passes with it under `--rerun-tasks`).

## Verification

- `./gradlew :plugin:functionalTest --tests "*can attach to application run task*" --rerun-tasks` — green, run repeatedly
- `./gradlew :otel:functionalTest --rerun-tasks` — green (implicit-dependency validation no longer tripped; reproduced the failure first, then confirmed the fix)
- `./gradlew build` — green (including spotless formatting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix build-ordering race by tracking javaagent config as a run task input
> - Registers the `javaagent` configuration as an explicit input on the `run` task in [`JavaagentApplicationRunPlugin`](https://github.com/ryandens/javaagent-gradle-plugin/pull/376/files#diff-f71f03c97e75e5fdaa8ccd2313acdd4e7301eeca6129362fbd839c5305967e11), so Gradle orders agent-building tasks before the run task.
> - Fixes [`JavaagentOTelModificationPlugin`](https://github.com/ryandens/javaagent-gradle-plugin/pull/376/files#diff-83d36b3e766e470c71ef1420617937717828310005145493c4e8a7f7d94ad1ae) to add the `extendedAgent` artifact via `project.files(extendedAgent)` instead of resolving it to a plain `File`, preserving `TaskProvider` provenance and its `builtBy` dependency.
> - Adds a functional test that uses `--dry-run` to assert `:simple-agent:jar` is scheduled before `:hello-world:run`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4dafe32.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->