### PR TITLE
:rotating_light: expand javadocs to be complete to resolve compiler warnings

### DIFF
--- a/jib-common/src/main/java/com/ryandens/javaagent/jib/JibExtensionConfiguration.java
+++ b/jib-common/src/main/java/com/ryandens/javaagent/jib/JibExtensionConfiguration.java
@@ -22,12 +22,22 @@ public class JibExtensionConfiguration {
    * Instantiated by Jib's plugin extension mechanism
    *
    * <p>Not compatible with configuration cache due to usage of Project at task execution time.
+   *
+   * @param project this extension is being applied to. Not ideal for configuration cache, but
+   *     mandated by jib extension architecture.
    */
   @Inject
   public JibExtensionConfiguration(final Project project) {
     this(project.getObjects());
   }
 
+  /**
+   * Constructor to allows for instantiation of this extension configuration by alternate jib-like
+   * frameworks such as <a href="https://github.com/pschichtel/tiny-jib">tel.schich.tinyjib</a>
+   *
+   * @param objectFactory to create {@link org.gradle.api.provider.Property} objects required by
+   *     this class.
+   */
   public JibExtensionConfiguration(final ObjectFactory objectFactory) {
     javaagentFiles = objectFactory.listProperty(File.class);
   }


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
### Add missing `@param` Javadoc tags to `JibExtensionConfiguration` constructors to resolve compiler warnings
Adds `@param` documentation to both constructors in [JibExtensionConfiguration.java](https://github.com/ryandens/javaagent-gradle-plugin/pull/377/files#diff-0d6dbaa8b94a42f0c8910030988ba92987a7faf1c743230db897f177a1c7fa0e) to fix incomplete Javadoc compiler warnings. The `Project` constructor documents the parameter's role and configuration cache implications; the `ObjectFactory` constructor gets a new Javadoc block explaining its use with alternate jib-like frameworks.

<!-- Macroscope's review summary starts here -->

<sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73f5657.</sup>
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->