### PR TITLE
ci: add TestLens setup to Gradle build workflow

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,5 +31,8 @@ jobs:
         with:
           cache-read-only: false
 
+      - name: Setup TestLens
+        uses: testlens-app/setup-testlens@v1
+
       - name: Execute Gradle build
         run: ${{ matrix.platform == 'windows-latest' && '.\gradlew.bat' || './gradlew' }} build


### PR DESCRIPTION
Adds the `testlens-app/setup-testlens@v1` step to the `build` job in `.github/workflows/gradle.yml`, following the [action's docs](https://github.com/testlens-app/setup-testlens).

The step is placed after `setup-gradle` and before `./gradlew build`, so the action writes its Gradle init script (which instruments all `Test` tasks) before the build runs.

The TestLens GitHub App is already installed on this repo, so no extra inputs or secrets are needed. The step runs on the existing ubuntu + windows matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add TestLens setup step to Gradle CI build workflow
> Adds a `testlens-app/setup-testlens@v1` step in [gradle.yml](.github/workflows/gradle.yml) before the Gradle build runs on both `ubuntu-latest` and `windows-latest` matrix platforms.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized db32404.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->